### PR TITLE
Fix broken "npm install" and memory leaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,16 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 
 # Essential include files to build a node addon,
 # You should add this line in every CMake.js based project
-#target_include_directories(${PROJECT_NAME} )
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
 
 # Include N-API wrappers
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC} PRIVATE "${CMAKE_SOURCE_DIR}/node_modules/node-addon-api")
+execute_process(COMMAND node -p "require('node-addon-api').include"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE NODE_ADDON_API_DIR
+    )
+string(REPLACE "\n" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
+string(REPLACE "\"" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
+target_include_directories(${PROJECT_NAME} PRIVATE ${NODE_ADDON_API_DIR})
 
 # Essential library files to link to a node addon
 # You should add this line in every CMake.js based project

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,20 +177,15 @@
             }
         },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+            "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
+                "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
-        },
-        "amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
         "ansi": {
             "version": "0.3.1",
@@ -226,9 +221,9 @@
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -381,9 +376,9 @@
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -394,15 +389,14 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "optional": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
         },
         "big-integer": {
-            "version": "1.6.36",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-            "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
+            "version": "1.6.48",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+            "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
         },
         "binary": {
             "version": "0.3.0",
@@ -419,9 +413,9 @@
             "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
         },
         "bluebird": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-            "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -489,9 +483,9 @@
             }
         },
         "chownr": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-            "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "clamp": {
             "version": "1.0.1",
@@ -510,11 +504,10 @@
             }
         },
         "cmake-js": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-4.0.0.tgz",
-            "integrity": "sha512-H90o+7ReoOo44lCohd8B856pdgTIvMzMnt/pUMDbTuF4L+A2/Hb1CKYQ5TE6lKLLoFZggIL97BG7Acc7y6a5Fg==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.1.0.tgz",
+            "integrity": "sha512-utmukLQftpgrCpGRCaHnkv4K27HZNNFqmBl4vnvccy0xp4c1erxjFU/Lq4wn5ngAhFZmpwBPQfoKWKThjSBiwg==",
             "requires": {
-                "bluebird": "^3",
                 "debug": "^4",
                 "fs-extra": "^5.0.0",
                 "is-iojs": "^1.0.1",
@@ -526,17 +519,11 @@
                 "semver": "^5.0.3",
                 "splitargs": "0",
                 "tar": "^4",
-                "traceur": "0.0.x",
                 "unzipper": "^0.8.13",
                 "url-join": "0",
                 "which": "^1.0.9",
                 "yargs": "^3.6.0"
             }
-        },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "code-point-at": {
             "version": "1.1.0",
@@ -559,19 +546,11 @@
             "dev": true
         },
         "combined-stream": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "requires": {
                 "delayed-stream": "~1.0.0"
-            }
-        },
-        "commander": {
-            "version": "2.9.0",
-            "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-            "requires": {
-                "graceful-readlink": ">= 1.0.0"
             }
         },
         "concat-map": {
@@ -599,17 +578,17 @@
             "dev": true
         },
         "debug": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.0.1.tgz",
-            "integrity": "sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
             "requires": {
                 "ms": "^2.1.1"
             },
             "dependencies": {
                 "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
         },
@@ -653,9 +632,9 @@
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -680,7 +659,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "optional": true,
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -709,14 +687,14 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
         },
         "fast-json-stable-stringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -724,12 +702,12 @@
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "requires": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
+                "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
         },
@@ -744,11 +722,11 @@
             }
         },
         "fs-minipass": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
             "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "^2.6.0"
             }
         },
         "fs.realpath": {
@@ -757,9 +735,9 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fstream": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -788,13 +766,14 @@
             }
         },
         "glob": {
-            "version": "5.0.15",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-            "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "2 || 3",
+                "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             }
@@ -806,14 +785,9 @@
             "dev": true
         },
         "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
-        "graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
         },
         "growl": {
             "version": "1.10.5",
@@ -827,11 +801,11 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-            "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "requires": {
-                "ajv": "^5.3.0",
+                "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
             }
         },
@@ -1003,8 +977,7 @@
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "optional": true
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
         },
         "jsesc": {
             "version": "2.5.1",
@@ -1018,9 +991,9 @@
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -1115,16 +1088,16 @@
             }
         },
         "mime-db": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+            "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
         },
         "mime-types": {
-            "version": "2.1.20",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "version": "2.1.26",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+            "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
             "requires": {
-                "mime-db": "~1.36.0"
+                "mime-db": "1.43.0"
             }
         },
         "minimatch": {
@@ -1137,24 +1110,24 @@
         },
         "minimist": {
             "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minipass": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
-            "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
             "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
             }
         },
         "minizlib": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-            "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
             "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "^2.9.0"
             }
         },
         "mkdirp": {
@@ -1307,6 +1280,7 @@
                     "version": "0.1.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "kind-of": "^3.0.2",
                         "longest": "^1.0.1",
@@ -1628,7 +1602,8 @@
                 "is-buffer": {
                     "version": "1.1.6",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "is-builtin-module": {
                     "version": "1.0.0",
@@ -1712,6 +1687,7 @@
                     "version": "3.2.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -1758,7 +1734,8 @@
                 "longest": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "lru-cache": {
                     "version": "4.1.3",
@@ -2024,7 +2001,8 @@
                 "repeat-string": {
                     "version": "1.6.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "require-directory": {
                     "version": "2.1.1",
@@ -2422,7 +2400,7 @@
         },
         "os-locale": {
             "version": "1.4.0",
-            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "requires": {
                 "lcid": "^1.0.0"
@@ -2476,19 +2454,19 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "psl": {
-            "version": "1.1.29",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+            "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
         },
         "punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "qs": {
             "version": "6.5.2",
@@ -2508,7 +2486,7 @@
         },
         "readable-stream": {
             "version": "1.0.34",
-            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
             "requires": {
                 "core-util-is": "~1.0.0",
@@ -2518,9 +2496,9 @@
             }
         },
         "request": {
-            "version": "2.88.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "requires": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -2529,7 +2507,7 @@
                 "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
                 "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
+                "har-validator": "~5.1.3",
                 "http-signature": "~1.2.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
@@ -2539,38 +2517,18 @@
                 "performance-now": "^2.1.0",
                 "qs": "~6.5.2",
                 "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
+                "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^3.3.2"
             }
         },
         "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "requires": {
-                "glob": "^7.0.5"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                }
+                "glob": "^7.1.3"
             }
-        },
-        "rsvp": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
         },
         "safe-buffer": {
             "version": "5.1.2",
@@ -2620,31 +2578,15 @@
                 }
             }
         },
-        "source-map": {
-            "version": "0.1.32",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-            "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-            "requires": {
-                "amdefine": ">=0.0.4"
-            }
-        },
-        "source-map-support": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-            "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-            "requires": {
-                "source-map": "0.1.32"
-            }
-        },
         "splitargs": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
             "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs="
         },
         "sshpk": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -2695,17 +2637,17 @@
             }
         },
         "tar": {
-            "version": "4.4.6",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
-            "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
+            "version": "4.4.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+            "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
             "requires": {
-                "chownr": "^1.0.1",
+                "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.3",
-                "minizlib": "^1.1.0",
+                "minipass": "^2.8.6",
+                "minizlib": "^1.2.1",
                 "mkdirp": "^0.5.0",
                 "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
+                "yallist": "^3.0.3"
             }
         },
         "text-encoding": {
@@ -2732,31 +2674,12 @@
             "dev": true
         },
         "tough-cookie": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-            }
-        },
-        "traceur": {
-            "version": "0.0.111",
-            "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.111.tgz",
-            "integrity": "sha1-wE3nTRRpbDNzQn3k/Ajsr5E/w6E=",
-            "requires": {
-                "commander": "2.9.x",
-                "glob": "5.0.x",
-                "rsvp": "^3.0.13",
-                "semver": "^4.3.3",
-                "source-map-support": "~0.2.8"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
-                }
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             }
         },
         "traverse": {
@@ -2781,8 +2704,7 @@
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "optional": true
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "type-detect": {
             "version": "4.0.8",
@@ -2817,11 +2739,6 @@
                 "setimmediate": "~1.0.4"
             },
             "dependencies": {
-                "bluebird": {
-                    "version": "3.4.7",
-                    "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-                    "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
-                },
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2834,7 +2751,7 @@
                 },
                 "readable-stream": {
                     "version": "2.1.5",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                     "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
                     "requires": {
                         "buffer-shims": "^1.0.0",
@@ -2848,6 +2765,14 @@
                 }
             }
         },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
         "url-join": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
@@ -2859,9 +2784,9 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "verror": {
             "version": "1.10.0",
@@ -2888,7 +2813,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
                 "string-width": "^1.0.1",
@@ -2912,13 +2837,13 @@
             "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
         },
         "yallist": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-            "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         },
         "yargs": {
             "version": "3.32.0",
-            "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
             "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
             "requires": {
                 "camelcase": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "wav"
     ],
     "scripts": {
-        "install": "cmake-js compile",
+        "install": "cmake-js build",
         "test": "nyc mocha test/*.test.js",
         "build:dev": "cmake-js build --debug",
         "build": "cmake-js build",
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "bindings": "^1.3.0",
-        "cmake-js": "^4.0.0",
+        "cmake-js": "^6.0.0",
         "node-addon-api": "^1.4.0"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "wav"
     ],
     "scripts": {
-        "install": "cmake-js build",
+        "install": "cmake-js rebuild",
         "test": "nyc mocha test/*.test.js",
         "build:dev": "cmake-js build --debug",
         "build": "cmake-js build",

--- a/src/node-libsamplerate.cc
+++ b/src/node-libsamplerate.cc
@@ -196,7 +196,7 @@ Napi::Value SampleRateStream::Transform(const Napi::CallbackInfo &info)
 void SampleRateStream::SetRatio(const Napi::CallbackInfo &info)
 {
     double ratio = info[0].As<Napi::Number>().DoubleValue();
-    data.src_ratio = ratio;
+    src_ratio = ratio;
 }
 
 void SampleRateStream::Reset(const Napi::CallbackInfo &info)

--- a/src/node-libsamplerate.cc
+++ b/src/node-libsamplerate.cc
@@ -186,7 +186,11 @@ Napi::Value SampleRateStream::Transform(const Napi::CallbackInfo &info)
     delete[] dataOutFloat;
     delete[] dataInFloat;
     
-    return Napi::Buffer<char>::New(env, (char *)dataOut, lengthOut);
+    // See https://github.com/nodejs/node-addon-api/blob/master/doc/buffer.md#new-1
+    Napi::Buffer<char> result = Napi::Buffer<char>::Copy(env, (char *)dataOut, lengthOut);
+    delete[] dataOut;
+    
+    return result;
 }
 
 void SampleRateStream::SetRatio(const Napi::CallbackInfo &info)

--- a/src/node-libsamplerate.cc
+++ b/src/node-libsamplerate.cc
@@ -183,6 +183,9 @@ Napi::Value SampleRateStream::Transform(const Napi::CallbackInfo &info)
         src_float_to_int_array(dataOutFloat, (int *)dataOut, lengthOut);
     }
 
+    delete[] dataOutFloat;
+    delete[] dataInFloat;
+    
     return Napi::Buffer<char>::New(env, (char *)dataOut, lengthOut);
 }
 

--- a/src/node-libsamplerate.h
+++ b/src/node-libsamplerate.h
@@ -1,7 +1,5 @@
 #include <napi.h>
 
-#include "../deps/include/samplerate.h"
-
 class SampleRateStream : public Napi::ObjectWrap<SampleRateStream> {
     public:
         static Napi::Object Init(Napi::Env env, Napi::Object exports);

--- a/src/node-libsamplerate.h
+++ b/src/node-libsamplerate.h
@@ -1,5 +1,7 @@
 #include <napi.h>
 
+#include "../deps/include/samplerate.h"
+
 class SampleRateStream : public Napi::ObjectWrap<SampleRateStream> {
     public:
         static Napi::Object Init(Napi::Env env, Napi::Object exports);
@@ -11,4 +13,5 @@ class SampleRateStream : public Napi::ObjectWrap<SampleRateStream> {
         Napi::Value Transform(const Napi::CallbackInfo& info);
         void SetRatio(const Napi::CallbackInfo& info);
         void Reset(const Napi::CallbackInfo& info);
+        double src_ratio;
 };


### PR DESCRIPTION
Hi @dmooney65 
First of all thanks for making the nice addon we are using this on a bot
But I ended up facing several problems, so I had to fix them

1. `npm install node-libsamplerate` no longer works properly, (supposedly) due to CMake-JS changed the manner of use of it.
2. The addon reveals its `src_ratio` related problem when two or more input streams exist on an event loop and their input samplerates varies (so do the ratios, of course).  
3. There are bits of memory leaking in the code, I've fixed it as well. (Our bot ate up 8GB RAM in just three days!)

Anyways, hope you can take a look at it 😄 